### PR TITLE
Update parsley-rails gem

### DIFF
--- a/kajabi_parsley.gemspec
+++ b/kajabi_parsley.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency 'parsley-rails', '~> 2.0.3'
+  spec.add_dependency 'parsley-rails', '~> 2.8.1.0'
 
   spec.add_development_dependency "rails"
 

--- a/lib/kajabi_parsley/version.rb
+++ b/lib/kajabi_parsley/version.rb
@@ -1,3 +1,3 @@
 module KajabiParsley
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
Updates dependency to most recent version of `parsley-rails`. In an attempt to stay on top of email validations, it is important we update our validator to the most recent version.

Versioning is patch since external API does not change