### PR TITLE
Fix dependabot alerts

### DIFF
--- a/kajabi_parsley.gemspec
+++ b/kajabi_parsley.gemspec
@@ -23,6 +23,6 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "rails"
 
-  spec.add_development_dependency "bundler", "~> 1.8"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "bundler", "~> 2.2.10"
+  spec.add_development_dependency "rake", "~> 12.3.3"
 end

--- a/lib/kajabi_parsley/version.rb
+++ b/lib/kajabi_parsley/version.rb
@@ -1,3 +1,3 @@
 module KajabiParsley
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 end


### PR DESCRIPTION
### Description
Fixes a high and moderate severity dependabot alert.

### Solution
- Updated `rake` and `bundler` dev dependencies to the most stable patch versions in the gempsec 
- Ensure that this won't cause any issues with kajabi-products: https://github.com/Kajabi/kajabi-products/pull/19511
- We'll publish this release to rubygems once this lands
- Question: Do we want to bump this over at kajabi-products, once it's published? Since these are only dev_dependencies, I'm not sure if it makes a difference. 